### PR TITLE
Add "Objective" parameter and improve text legibility

### DIFF
--- a/lib/protractor-exporter.js
+++ b/lib/protractor-exporter.js
@@ -1,15 +1,16 @@
 'use strict';
 
 var data = {};
+var htmlToText = require('html-to-text');
 
 function exportTestCaseMethod(result) {
     data.id = escapeString(result.Object.FormattedID);
     data.priority = escapeString(result.Object.Priority);
     data.name = escapeString(result.Object.Name);
-    data.objective = escapeString(result.Object.Objective);
-    data.pre_condition = escapeString(result.Object.PreConditions);
-    data.validation_input = escapeString(result.Object.ValidationInput);
-    data.validation_expected_result = escapeString(result.Object.ValidationExpectedResult);
+    data.objective = htmlToText.fromString(result.Object.Objective, {wordwrap: 120});
+    data.pre_condition = htmlToText.fromString(result.Object.PreConditions, {wordwrap: 120});
+    data.validation_input = htmlToText.fromString(result.Object.ValidationInput, {wordwrap: 120});
+    data.validation_expected_result = htmlToText.fromString(result.Object.ValidationExpectedResult, {wordwrap: 120});
 }
 
 function exportSteps(result) {

--- a/lib/protractor-exporter.js
+++ b/lib/protractor-exporter.js
@@ -6,6 +6,7 @@ function exportTestCaseMethod(result) {
     data.id = escapeString(result.Object.FormattedID);
     data.priority = escapeString(result.Object.Priority);
     data.name = escapeString(result.Object.Name);
+    data.objective = escapeString(result.Object.Objective);
     data.pre_condition = escapeString(result.Object.PreConditions);
     data.validation_input = escapeString(result.Object.ValidationInput);
     data.validation_expected_result = escapeString(result.Object.ValidationExpectedResult);

--- a/lib/rally-client.js
+++ b/lib/rally-client.js
@@ -25,7 +25,7 @@ function init(username, password, exp) {
 function readTestCase(tcId) {
     return restApi.get({
         ref: '/testcase/' + tcId,
-        fetch: ['FormattedID', 'Name', 'Steps', 'Priority', 'PreConditions', 'ValidationInput', 'ValidationExpectedResult']
+        fetch: ['FormattedID', 'Name', 'Objective', 'Steps', 'Priority', 'PreConditions', 'ValidationInput', 'ValidationExpectedResult']
     });
 }
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "rally": "0.1.4",
     "copy-paste": "1.0.1",
-    "hogan.js": "3.0.2"
+    "hogan.js": "3.0.2",
+    "html-to-text": "1.1.1"
   },
   "keywords": [
     "rally",


### PR DESCRIPTION
* Add "Objective" parameter to use on tc-export
* Improve text legibility of some parameters. Convert HTML to plain-text using "html-to-text" dependency